### PR TITLE
Change authorization type

### DIFF
--- a/walletsdk/src/main/java/com/mundipagg/util/Factory.java
+++ b/walletsdk/src/main/java/com/mundipagg/util/Factory.java
@@ -33,7 +33,7 @@ public class Factory {
             public Response intercept(Chain chain) throws IOException {
                 Request request = chain.request()
                         .newBuilder()
-                        .header("Authorization", "Bearer " + MundipaggAccount.getInstance().getAccessToken())
+                        .header("Authorization", "Basic " + MundipaggAccount.getInstance().getAccessToken())
                         .method(chain.request().method(), chain.request().body())
                         .build();
                 return chain.proceed(request);


### PR DESCRIPTION
Alterando a autenticação para basic, segundo a documentação da Mundipagg (https://docs.mundipagg.com/reference#autenticação) Basic é o padrão ultilizado